### PR TITLE
trimmed course-name when searching for events

### DIFF
--- a/timetable.js
+++ b/timetable.js
@@ -72,7 +72,7 @@ var putLessonGroupInCalendar = function (group) {
 var courses = [];
 
 var getCourse = function() {
-  var courseName = $("#course-name").val().toUpperCase();
+  var courseName = $("#course-name").val().toUpperCase().trim();
   if (courseName.length == 8 && courses.indexOf(courseName) === -1) {
     if (courseName == "ENGN1211") {
       $("#warningModal").modal();


### PR DESCRIPTION
I was momentarily frustrated on my phone when my keyboard autocompleted
with a space after the course code and the timetable didn't accept it.
therefore i cloned @bshlgrs's entire repository to fix it. am i doing it
right? am i doing it wrong?

Linked to a issue but not sure how to link them.